### PR TITLE
Getting a camera instance on a background thread

### DIFF
--- a/core/src/main/java/me/dm7/barcodescanner/core/BarcodeScannerView.java
+++ b/core/src/main/java/me/dm7/barcodescanner/core/BarcodeScannerView.java
@@ -30,6 +30,10 @@ public abstract class BarcodeScannerView extends FrameLayout implements Camera.P
         addView(mViewFinderView);
     }
 
+    private Camera.PreviewCallback getPreviewCallback(){
+        return this;
+    }
+    
     public void startCamera() {
         AsyncTask<Void, Void, Camera> getCameraInst = new AsyncTask<Void, Void, Camera>() {
             //Get a camera instance on a worked thread
@@ -42,7 +46,7 @@ public abstract class BarcodeScannerView extends FrameLayout implements Camera.P
             protected void onPostExecute(Camera mCamera) {
                 if(mCamera != null) {
                     mViewFinderView.setupViewFinder();
-                    mPreview.setCamera(mCamera, this);
+                    mPreview.setCamera(mCamera, getPreviewCallback());
                     mPreview.initCameraPreview();
                 }
             }


### PR DESCRIPTION
Getting a camera instance can take a long time. Now it is fetched by a worker thread instead.
