### PR TITLE
Fix camera preview stretching

### DIFF
--- a/core/src/main/java/me/dm7/barcodescanner/core/BarcodeScannerView.java
+++ b/core/src/main/java/me/dm7/barcodescanner/core/BarcodeScannerView.java
@@ -1,11 +1,14 @@
 package me.dm7.barcodescanner.core;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.hardware.Camera;
 import android.util.AttributeSet;
+import android.view.Gravity;
 import android.widget.FrameLayout;
+import android.widget.RelativeLayout;
 
 public abstract class BarcodeScannerView extends FrameLayout implements Camera.PreviewCallback  {
     private Camera mCamera;
@@ -26,7 +29,13 @@ public abstract class BarcodeScannerView extends FrameLayout implements Camera.P
     public void setupLayout() {
         mPreview = new CameraPreview(getContext());
         mViewFinderView = new ViewFinderView(getContext());
-        addView(mPreview);
+
+        RelativeLayout relativeLayout = new RelativeLayout(getContext());
+        relativeLayout.setGravity(Gravity.CENTER);
+        relativeLayout.setBackgroundColor(Color.BLACK);
+        relativeLayout.addView(mPreview);
+        addView(relativeLayout);
+
         addView(mViewFinderView);
     }
 

--- a/core/src/main/java/me/dm7/barcodescanner/core/CameraPreview.java
+++ b/core/src/main/java/me/dm7/barcodescanner/core/CameraPreview.java
@@ -10,6 +10,7 @@ import android.view.Display;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
+import android.view.ViewGroup;
 import android.view.WindowManager;
 
 import java.util.List;
@@ -104,6 +105,40 @@ public class CameraPreview extends SurfaceView implements SurfaceHolder.Callback
         Camera.Parameters parameters = mCamera.getParameters();
         parameters.setPreviewSize(optimalSize.width, optimalSize.height);
         mCamera.setParameters(parameters);
+        adjustViewSize(optimalSize);
+    }
+
+    private void adjustViewSize(Camera.Size cameraSize) {
+        Point screenSize =
+                convertSizeToLandscapeOrientation(DisplayUtils.getScreenResolution(getContext()));
+        float cameraRatio = ((float) cameraSize.width) / cameraSize.height;
+        float screenRatio = ((float) screenSize.x) / screenSize.y;
+
+        if (screenRatio > cameraRatio) {
+            setViewSize((int) (screenSize.y * cameraRatio), screenSize.y);
+        } else {
+            setViewSize(screenSize.x, (int) (screenSize.x / cameraRatio));
+        }
+    }
+
+    private Point convertSizeToLandscapeOrientation(Point size) {
+        if (getDisplayOrientation() % 180 == 0) {
+            return size;
+        } else {
+            return new Point(size.y, size.x);
+        }
+    }
+
+    private void setViewSize(int width, int height) {
+        ViewGroup.LayoutParams layoutParams = getLayoutParams();
+        if (getDisplayOrientation() % 180 == 0) {
+            layoutParams.width = width;
+            layoutParams.height = height;
+        } else {
+            layoutParams.width = height;
+            layoutParams.height = width;
+        }
+        setLayoutParams(layoutParams);
     }
 
     public int getDisplayOrientation() {


### PR DESCRIPTION
Fix camera preview view stretching by keeping the original aspect ratio and adding black borders if the view has different aspect ratio.
This fixes this issue https://github.com/dm77/barcodescanner/issues/8