### PR TITLE
Fixes wrong preview size in portrait mode

### DIFF
--- a/core/src/main/java/me/dm7/barcodescanner/core/CameraPreview.java
+++ b/core/src/main/java/me/dm7/barcodescanner/core/CameraPreview.java
@@ -1,6 +1,7 @@
 package me.dm7.barcodescanner.core;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.graphics.Point;
 import android.hardware.Camera;
 import android.os.Handler;
@@ -142,6 +143,10 @@ public class CameraPreview extends SurfaceView implements SurfaceHolder.Callback
         Point screenResolution = DisplayUtils.getScreenResolution(getContext());
         int w = screenResolution.x;
         int h = screenResolution.y;
+        if (DisplayUtils.getScreenOrientation(getContext()) == Configuration.ORIENTATION_PORTRAIT) {
+            w = screenResolution.y;
+            h = screenResolution.x;
+        }
 
 
         final double ASPECT_TOLERANCE = 0.1;


### PR DESCRIPTION
Hi! There is a problem with preview size in portrait mode, we need to swap x and y dimensions to get right targetRatio otherwise it fallback to closest height which is wrong anyway. This problem become critical when camera reports both portrait and landscape sizes in one list (Moto Atrix2 for ex.) and landscape aspect size are choosen in portrait mode as a result. 
