### PR TITLE
Added support for falling back on a front facing camera.

### DIFF
--- a/core/src/main/java/me/dm7/barcodescanner/core/CameraUtils.java
+++ b/core/src/main/java/me/dm7/barcodescanner/core/CameraUtils.java
@@ -7,6 +7,19 @@ import java.util.List;
 public class CameraUtils {
     /** A safe way to get an instance of the Camera object. */
     public static Camera getCameraInstance() {
+        return getCameraInstance(false);
+    }
+
+    /**
+     * A safe way to get an instance of the Camera object. If {@code tryFrontFacing} is
+     * true, and a default cam could not be found, a front facing cam will be tried.
+     *
+     * @param tryFrontFacing if true, and no default cam could be found, a front facing
+     *                       cam will be tried.
+     *
+     * @return a camera instance or null if one could not be found.
+     */
+    public static Camera getCameraInstance(boolean tryFrontFacing) {
         Camera c = null;
         try {
             c = Camera.open(); // attempt to get a Camera instance
@@ -14,7 +27,31 @@ public class CameraUtils {
         catch (Exception e) {
             // Camera is not available (in use or does not exist)
         }
-        return c; // returns null if camera is unavailable
+
+        if (c == null && !tryFrontFacing) {
+            return c; // returns null if camera is unavailable and we don't need to try a front facing cam
+        }
+
+        // Try to find a front facing cam.
+        try {
+            Camera.CameraInfo cameraInfo = new Camera.CameraInfo();
+            int cameraCount = Camera.getNumberOfCameras();
+
+            for (int i = 0; i < cameraCount; i++) {
+                Camera.getCameraInfo(i, cameraInfo);
+                if (cameraInfo.facing == Camera.CameraInfo.CAMERA_FACING_FRONT) {
+                    try {
+                        c = Camera.open(i);
+                    } catch (Exception e) {
+                        // ignore
+                    }
+                }
+            }
+        } catch (Exception e) {
+            // ignore
+        }
+
+        return c;
     }
 
     public static boolean isFlashSupported(Camera camera) {


### PR DESCRIPTION
`getCameraInstance()` returns `null` on devices with only a front facing cam (Nexus 7, 1st edition). In such cases, it could be nice to fall back on a front facing cam.