### PR TITLE
View init fixes

### DIFF
--- a/core/src/main/java/me/dm7/barcodescanner/core/CameraPreview.java
+++ b/core/src/main/java/me/dm7/barcodescanner/core/CameraPreview.java
@@ -21,7 +21,7 @@ public class CameraPreview extends SurfaceView implements SurfaceHolder.Callback
 
     private Camera mCamera;
     private Handler mAutoFocusHandler;
-    private boolean mPreviewing = true;
+    private boolean mPreviewing = false;
     private boolean mAutoFocus = true;
     private boolean mSurfaceCreated = false;
     private Camera.PreviewCallback mPreviewCallback;

--- a/core/src/main/java/me/dm7/barcodescanner/core/CameraPreview.java
+++ b/core/src/main/java/me/dm7/barcodescanner/core/CameraPreview.java
@@ -28,10 +28,12 @@ public class CameraPreview extends SurfaceView implements SurfaceHolder.Callback
 
     public CameraPreview(Context context) {
         super(context);
+        setupSurfaceHolder();
     }
 
     public CameraPreview(Context context, AttributeSet attrs) {
         super(context, attrs);
+        setupSurfaceHolder();
     }
 
     public void setCamera(Camera camera, Camera.PreviewCallback previewCallback) {
@@ -40,10 +42,13 @@ public class CameraPreview extends SurfaceView implements SurfaceHolder.Callback
         mAutoFocusHandler = new Handler();
     }
 
+    protected void setupSurfaceHolder() {
+        getHolder().addCallback(this);
+        getHolder().setType(SurfaceHolder.SURFACE_TYPE_PUSH_BUFFERS);
+    }
+
     public void initCameraPreview() {
         if(mCamera != null) {
-            getHolder().addCallback(this);
-            getHolder().setType(SurfaceHolder.SURFACE_TYPE_PUSH_BUFFERS);
             if(mPreviewing) {
                 requestLayout();
             } else {


### PR DESCRIPTION
This fixes make CameraPreview&BarcodeScannerView work if startCamera is called not in activity/fragment onCreate but sometime after. Current code won't initialize preview at all in such scenario.
One case when one might want such order of events is just not wanting to start camera right away (maybe let the user choose a camera first, or just due to app's UI design). Another is if we'd want onPreviewFrame to be run on WorkerThread. The thread is determined in camera.open() call, so one'd first create activity/fragment, then obtain camera in WorkerThread and then finally call startCamera(camera) in MainThread which'll most likely run after onCreate is done.