### PR TITLE
Fixup package name for CameraPreview and ViewFinderView in a layout

### DIFF
--- a/core/src/main/res/layout/merge_camera_preview_view_finder.xml
+++ b/core/src/main/res/layout/merge_camera_preview_view_finder.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android">
-    <me.dm7.barcodescannerview.CameraPreview
+    <me.dm7.barcodescannerview.core.CameraPreview
          android:id="@+id/camera_preview"
          android:layout_width="fill_parent"
          android:layout_height="fill_parent"/>
-    <me.dm7.barcodescannerview.ViewFinderView
+    <me.dm7.barcodescannerview.core.ViewFinderView
         android:id="@+id/view_finder_view"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent" />


### PR DESCRIPTION
It's always been me.dm7.barcodescannerview.core rather than
me.dm7.barcodescannerview. Seems like nobody uses this layout
but still worth fixing as proguard gives warnings like:

Note: the configuration refers to the unknown class 'me.dm7.barcodescannerview.CameraPreview'
Maybe you meant the fully qualified name 'me.dm7.barcodescanner.core.CameraPreview'

Note: the configuration refers to the unknown class 'me.dm7.barcodescannerview.ViewFinderView'
Maybe you meant the fully qualified name 'me.dm7.barcodescanner.core.ViewFinderView'