### PR TITLE
Update SimpleScannerActivity.java

### DIFF
--- a/zbar-sample/src/main/java/me/dm7/barcodescanner/zbar/sample/SimpleScannerActivity.java
+++ b/zbar-sample/src/main/java/me/dm7/barcodescanner/zbar/sample/SimpleScannerActivity.java
@@ -25,6 +25,7 @@ public class SimpleScannerActivity extends BaseScannerActivity implements ZBarSc
     public void onResume() {
         super.onResume();
         mScannerView.setResultHandler(this);
+        // Defaults to CAMERA_FACING_FRONT (1).
         mScannerView.startCamera();
     }
 


### PR DESCRIPTION
Brief comment how the scannerView.startCamera() method defaults to the front camera.