### PR TITLE
Add option for scaling the camera preview

### DIFF
--- a/core/src/main/java/me/dm7/barcodescanner/core/BarcodeScannerView.java
+++ b/core/src/main/java/me/dm7/barcodescanner/core/BarcodeScannerView.java
@@ -31,11 +31,16 @@ public abstract class BarcodeScannerView extends FrameLayout implements Camera.P
         removeAllViews();
 
         mPreview = new CameraPreview(getContext(), camera, this);
-        RelativeLayout relativeLayout = new RelativeLayout(getContext());
-        relativeLayout.setGravity(Gravity.CENTER);
-        relativeLayout.setBackgroundColor(Color.BLACK);
-        relativeLayout.addView(mPreview);
-        addView(relativeLayout);
+        boolean shouldFillView = getContext().getResources().getBoolean(R.bool.cameraPreviewShouldFillView);
+        if (!shouldFillView) {
+            RelativeLayout relativeLayout = new RelativeLayout(getContext());
+            relativeLayout.setGravity(Gravity.CENTER);
+            relativeLayout.setBackgroundColor(Color.BLACK);
+            relativeLayout.addView(mPreview);
+            addView(relativeLayout);
+        } else {
+            addView(mPreview);
+        }
 
         mViewFinderView = createViewFinderView(getContext());
         if (mViewFinderView instanceof View) {

--- a/core/src/main/java/me/dm7/barcodescanner/core/BarcodeScannerView.java
+++ b/core/src/main/java/me/dm7/barcodescanner/core/BarcodeScannerView.java
@@ -1,6 +1,7 @@
 package me.dm7.barcodescanner.core;
 
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.Rect;
 import android.hardware.Camera;
@@ -18,6 +19,7 @@ public abstract class BarcodeScannerView extends FrameLayout implements Camera.P
     private CameraHandlerThread mCameraHandlerThread;
     private Boolean mFlashState;
     private boolean mAutofocusState = true;
+    private boolean mShouldScaleToFill = true;
 
     public BarcodeScannerView(Context context) {
         super(context);
@@ -25,14 +27,24 @@ public abstract class BarcodeScannerView extends FrameLayout implements Camera.P
 
     public BarcodeScannerView(Context context, AttributeSet attributeSet) {
         super(context, attributeSet);
+        TypedArray a = context.getTheme().obtainStyledAttributes(
+                attributeSet,
+                R.styleable.BarcodeScannerView,
+                0, 0);
+
+        try {
+            setShouldScaleToFill(a.getBoolean(R.styleable.BarcodeScannerView_shouldScaleToFill, true));
+        } finally {
+            a.recycle();
+        }
     }
 
     public final void setupLayout(Camera camera) {
         removeAllViews();
 
         mPreview = new CameraPreview(getContext(), camera, this);
-        boolean shouldFillView = getContext().getResources().getBoolean(R.bool.cameraPreviewShouldFillView);
-        if (!shouldFillView) {
+        mPreview.setShouldScaleToFill(mShouldScaleToFill);
+        if (!mShouldScaleToFill) {
             RelativeLayout relativeLayout = new RelativeLayout(getContext());
             relativeLayout.setGravity(Gravity.CENTER);
             relativeLayout.setBackgroundColor(Color.BLACK);
@@ -179,5 +191,9 @@ public abstract class BarcodeScannerView extends FrameLayout implements Camera.P
         if(mPreview != null) {
             mPreview.setAutoFocus(state);
         }
+    }
+
+    public void setShouldScaleToFill(boolean shouldScaleToFill) {
+        mShouldScaleToFill = shouldScaleToFill;
     }
 }

--- a/core/src/main/java/me/dm7/barcodescanner/core/CameraPreview.java
+++ b/core/src/main/java/me/dm7/barcodescanner/core/CameraPreview.java
@@ -11,6 +11,7 @@ import android.view.Display;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
+import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
 
@@ -135,6 +136,7 @@ public class CameraPreview extends SurfaceView implements SurfaceHolder.Callback
         }
     }
 
+    @SuppressWarnings("SuspiciousNameCombination")
     private Point convertSizeToLandscapeOrientation(Point size) {
         if (getDisplayOrientation() % 180 == 0) {
             return size;
@@ -143,15 +145,41 @@ public class CameraPreview extends SurfaceView implements SurfaceHolder.Callback
         }
     }
 
+    @SuppressWarnings("SuspiciousNameCombination")
     private void setViewSize(int width, int height) {
         ViewGroup.LayoutParams layoutParams = getLayoutParams();
+        int tmpWidth;
+        int tmpHeight;
         if (getDisplayOrientation() % 180 == 0) {
-            layoutParams.width = width;
-            layoutParams.height = height;
+            tmpWidth = width;
+            tmpHeight = height;
         } else {
-            layoutParams.width = height;
-            layoutParams.height = width;
+            tmpWidth = height;
+            tmpHeight = width;
         }
+
+        boolean shouldFillView = getContext().getResources().getBoolean(R.bool.cameraPreviewShouldFillView);
+
+        if (shouldFillView) {
+            int parentWidth = ((View) getParent()).getWidth();
+            int parentHeight = ((View) getParent()).getHeight();
+            float ratioWidth = (float) parentWidth / (float) tmpWidth;
+            float ratioHeight = (float) parentHeight / (float) tmpHeight;
+
+            float compensation;
+
+            if (ratioWidth > ratioHeight) {
+                compensation = ratioWidth;
+            } else {
+                compensation = ratioHeight;
+            }
+
+            tmpWidth = Math.round(tmpWidth * compensation);
+            tmpHeight = Math.round(tmpHeight * compensation);
+        }
+
+        layoutParams.width = tmpWidth;
+        layoutParams.height = tmpHeight;
         setLayoutParams(layoutParams);
     }
 

--- a/core/src/main/java/me/dm7/barcodescanner/core/CameraPreview.java
+++ b/core/src/main/java/me/dm7/barcodescanner/core/CameraPreview.java
@@ -25,6 +25,7 @@ public class CameraPreview extends SurfaceView implements SurfaceHolder.Callback
     private boolean mPreviewing = true;
     private boolean mAutoFocus = true;
     private boolean mSurfaceCreated = false;
+    private boolean mShouldScaleToFill = true;
     private Camera.PreviewCallback mPreviewCallback;
 
     public CameraPreview(Context context, Camera camera, Camera.PreviewCallback previewCallback) {
@@ -47,6 +48,10 @@ public class CameraPreview extends SurfaceView implements SurfaceHolder.Callback
     public void setCamera(Camera camera, Camera.PreviewCallback previewCallback) {
         mCamera = camera;
         mPreviewCallback = previewCallback;
+    }
+
+    public void setShouldScaleToFill(boolean scaleToFill) {
+        mShouldScaleToFill = scaleToFill;
     }
 
     @Override
@@ -158,9 +163,7 @@ public class CameraPreview extends SurfaceView implements SurfaceHolder.Callback
             tmpHeight = width;
         }
 
-        boolean shouldFillView = getContext().getResources().getBoolean(R.bool.cameraPreviewShouldFillView);
-
-        if (shouldFillView) {
+        if (mShouldScaleToFill) {
             int parentWidth = ((View) getParent()).getWidth();
             int parentHeight = ((View) getParent()).getHeight();
             float ratioWidth = (float) parentWidth / (float) tmpWidth;

--- a/core/src/main/res/values/attrs.xml
+++ b/core/src/main/res/values/attrs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="BarcodeScannerView">
+        <attr name="shouldScaleToFill" format="boolean" />
+    </declare-styleable>
+</resources>

--- a/core/src/main/res/values/bools.xml
+++ b/core/src/main/res/values/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="cameraPreviewShouldFillView">false</bool>
+</resources>

--- a/core/src/main/res/values/bools.xml
+++ b/core/src/main/res/values/bools.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <bool name="cameraPreviewShouldFillView">false</bool>
-</resources>


### PR DESCRIPTION
Whether or not to scale the preview is defined by the boolean resource `cameraPreviewShouldFillView`. Default is false, but can be overridden by applications by defining

```xml
<?xml version="1.0" encoding="utf-8"?>
<resources>
  <bool name="cameraPreviewShouldFillView">true</bool>
</resources> 
```

This should not cause problems due to stretching, as aspect ratio is maintained, by not wrapping the preview in a RelativeLayout (keeping FrameLayout as parent, which clips/crops).