### PR TITLE
Added hideViewFider to hide the viewfinder from the preview

### DIFF
--- a/core/src/main/java/me/dm7/barcodescanner/core/BarcodeScannerView.java
+++ b/core/src/main/java/me/dm7/barcodescanner/core/BarcodeScannerView.java
@@ -20,6 +20,7 @@ public abstract class BarcodeScannerView extends FrameLayout implements Camera.P
     private Boolean mFlashState;
     private boolean mAutofocusState = true;
     private boolean mShouldScaleToFill = true;
+    private boolean showViewFinder = true;
 
     public BarcodeScannerView(Context context) {
         super(context);
@@ -54,13 +55,16 @@ public abstract class BarcodeScannerView extends FrameLayout implements Camera.P
             addView(mPreview);
         }
 
-        mViewFinderView = createViewFinderView(getContext());
-        if (mViewFinderView instanceof View) {
-            addView((View) mViewFinderView);
-        } else {
-            throw new IllegalArgumentException("IViewFinder object returned by " +
-                    "'createViewFinderView()' should be instance of android.view.View");
-        }
+            mViewFinderView = createViewFinderView(getContext());
+
+
+            if (mViewFinderView instanceof View) {
+                addView((View) mViewFinderView);
+            } else {
+                throw new IllegalArgumentException("IViewFinder object returned by " +
+                        "'createViewFinderView()' should be instance of android.view.View");
+            }
+
     }
 
     /**
@@ -71,7 +75,10 @@ public abstract class BarcodeScannerView extends FrameLayout implements Camera.P
      * @return {@link android.view.View} that implements {@link ViewFinderView}
      */
     protected IViewFinder createViewFinderView(Context context) {
-        return new ViewFinderView(context);
+        if (showViewFinder)
+            return new ViewFinderView(context);
+        else
+            return new TransparentViewFinderView(context);
     }
 
     public void startCamera(int cameraId) {
@@ -85,7 +92,8 @@ public abstract class BarcodeScannerView extends FrameLayout implements Camera.P
         mCameraWrapper = cameraWrapper;
         if(mCameraWrapper != null) {
             setupLayout(mCameraWrapper);
-            mViewFinderView.setupViewFinder();
+            if (showViewFinder)
+                mViewFinderView.setupViewFinder();
             if(mFlashState != null) {
                 setFlash(mFlashState);
             }
@@ -123,6 +131,7 @@ public abstract class BarcodeScannerView extends FrameLayout implements Camera.P
     }
 
     public synchronized Rect getFramingRectInPreview(int previewWidth, int previewHeight) {
+
         if (mFramingRectInPreview == null) {
             Rect framingRect = mViewFinderView.getFramingRect();
             int viewFinderViewWidth = mViewFinderView.getWidth();
@@ -197,6 +206,10 @@ public abstract class BarcodeScannerView extends FrameLayout implements Camera.P
         if(mPreview != null) {
             mPreview.setAutoFocus(state);
         }
+    }
+
+    public void hideViewFinder() {
+        this.showViewFinder = false;
     }
 
     public void setShouldScaleToFill(boolean shouldScaleToFill) {

--- a/core/src/main/java/me/dm7/barcodescanner/core/TransparentViewFinderView.java
+++ b/core/src/main/java/me/dm7/barcodescanner/core/TransparentViewFinderView.java
@@ -1,0 +1,44 @@
+package me.dm7.barcodescanner.core;
+
+import android.content.Context;
+import android.content.res.Configuration;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Point;
+import android.graphics.Rect;
+import android.util.AttributeSet;
+import android.view.View;
+
+public class TransparentViewFinderView extends View implements IViewFinder {
+    private static final String TAG = "ViewFinderView";
+
+    private Rect mFramingRect;
+
+    public TransparentViewFinderView(Context context) {
+        super(context);
+    }
+
+    public TransparentViewFinderView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+
+    public void setupViewFinder() {
+        updateFramingRect();
+        invalidate();
+    }
+
+    public Rect getFramingRect() {
+        return mFramingRect;
+    }
+
+
+    @Override
+    protected void onSizeChanged(int xNew, int yNew, int xOld, int yOld) {
+        updateFramingRect();
+    }
+
+    public synchronized void updateFramingRect() {
+        mFramingRect = new Rect(0, 0, getWidth(), getHeight());
+    }
+}

--- a/zbar-sample/build.gradle
+++ b/zbar-sample/build.gradle
@@ -2,10 +2,10 @@ apply plugin: 'com.android.application'
 
 dependencies {
     //compile project(":zbar")
-    compile 'me.dm7.barcodescanner:zbar:1.9'
-    compile supportLibraryDependency
-    compile 'com.android.support:appcompat-v7:24.1.1'
+    //compile 'me.dm7.barcodescanner:zbar:1.9'
+    //compile supportLibraryDependency compile 'com.android.support:appcompat-v7:24.1.1'
     compile 'com.android.support:design:24.1.1'
+    compile project(':zbar')
 }
 
 android {

--- a/zbar-sample/src/main/AndroidManifest.xml
+++ b/zbar-sample/src/main/AndroidManifest.xml
@@ -40,5 +40,10 @@
                 android:theme="@style/AppOverlayTheme"
                 android:label="@string/simple_scanner_fragment_activity">
         </activity>
+
+      <activity android:name=".SimpleScannerNoViewFinderFragmentActivity"
+          android:theme="@style/AppOverlayTheme"
+          android:label="@string/simple_scanner_fragment_activity">
+      </activity>
     </application>
 </manifest>

--- a/zbar-sample/src/main/java/me/dm7/barcodescanner/zbar/sample/MainActivity.java
+++ b/zbar-sample/src/main/java/me/dm7/barcodescanner/zbar/sample/MainActivity.java
@@ -35,6 +35,10 @@ public class MainActivity extends AppCompatActivity {
         launchActivity(SimpleScannerFragmentActivity.class);
     }
 
+    public void launchSimpleFragmentNoViewFinderActivity(View v) {
+        launchActivity(SimpleScannerNoViewFinderFragmentActivity.class);
+    }
+
     public void launchFullActivity(View v) {
         launchActivity(FullScannerActivity.class);
     }
@@ -42,6 +46,8 @@ public class MainActivity extends AppCompatActivity {
     public void launchFullFragmentActivity(View v) {
         launchActivity(FullScannerFragmentActivity.class);
     }
+
+
 
     public void launchActivity(Class<?> clss) {
         if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA)

--- a/zbar-sample/src/main/java/me/dm7/barcodescanner/zbar/sample/SimpleScannerNoViewFinderFragment.java
+++ b/zbar-sample/src/main/java/me/dm7/barcodescanner/zbar/sample/SimpleScannerNoViewFinderFragment.java
@@ -1,0 +1,53 @@
+package me.dm7.barcodescanner.zbar.sample;
+
+import android.os.Bundle;
+import android.os.Handler;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Toast;
+
+import me.dm7.barcodescanner.zbar.Result;
+import me.dm7.barcodescanner.zbar.ZBarScannerView;
+
+public class SimpleScannerNoViewFinderFragment extends Fragment implements ZBarScannerView.ResultHandler {
+    private ZBarScannerView mScannerView;
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        mScannerView = new ZBarScannerView(getActivity());
+        return mScannerView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        mScannerView.setResultHandler(this);
+        mScannerView.hideViewFinder();
+        mScannerView.startCamera();
+    }
+
+    @Override
+    public void handleResult(Result rawResult) {
+        Toast.makeText(getActivity(), "Contents = " + rawResult.getContents() +
+                ", Format = " + rawResult.getBarcodeFormat().getName(), Toast.LENGTH_SHORT).show();
+        // Note:
+        // * Wait 2 seconds to resume the preview.
+        // * On older devices continuously stopping and resuming camera preview can result in freezing the app.
+        // * I don't know why this is the case but I don't have the time to figure out.
+        Handler handler = new Handler();
+        handler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                mScannerView.resumeCameraPreview(SimpleScannerNoViewFinderFragment.this);
+            }
+        }, 2000);
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        mScannerView.stopCamera();
+    }
+}

--- a/zbar-sample/src/main/java/me/dm7/barcodescanner/zbar/sample/SimpleScannerNoViewFinderFragmentActivity.java
+++ b/zbar-sample/src/main/java/me/dm7/barcodescanner/zbar/sample/SimpleScannerNoViewFinderFragmentActivity.java
@@ -1,0 +1,12 @@
+package me.dm7.barcodescanner.zbar.sample;
+
+import android.os.Bundle;
+
+public class SimpleScannerNoViewFinderFragmentActivity extends BaseScannerActivity {
+    @Override
+    public void onCreate(Bundle state) {
+        super.onCreate(state);
+        setContentView(R.layout.activity_simple_scanner_no_viewfinder_fragment);
+        setupToolbar();
+    }
+}

--- a/zbar-sample/src/main/res/layout/activity_main.xml
+++ b/zbar-sample/src/main/res/layout/activity_main.xml
@@ -31,6 +31,10 @@
                 android:text="@string/simple_fragment_sample"
                 android:onClick="launchSimpleFragmentActivity" />
         <Button android:layout_height="wrap_content"
+            android:layout_width="match_parent"
+            android:text="@string/simple_fragment_no_viewfinder_sample"
+            android:onClick="launchSimpleFragmentNoViewFinderActivity" />
+        <Button android:layout_height="wrap_content"
                 android:layout_width="match_parent"
                 android:text="@string/activity_sample"
                 android:onClick="launchFullActivity" />

--- a/zbar-sample/src/main/res/layout/activity_simple_scanner_no_viewfinder_fragment.xml
+++ b/zbar-sample/src/main/res/layout/activity_simple_scanner_no_viewfinder_fragment.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <fragment android:name="me.dm7.barcodescanner.zbar.sample.SimpleScannerNoViewFinderFragment"
+              android:id="@+id/scanner_fragment"
+              android:layout_weight="1"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent" />
+
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_gravity="top"
+        android:minHeight="?attr/actionBarSize"
+        android:background="@color/actionbar_opacity"
+        app:theme="@style/TransparentToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+</FrameLayout>

--- a/zbar-sample/src/main/res/values/strings.xml
+++ b/zbar-sample/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="scanner_activity">ZBar Scanner - Full Activity</string>
     <string name="scanner_fragment_activity">ZBar Scanner - Full Fragment Activity</string>
     <string name="simple_scanner_activity">ZBar Scanner - Simple Activity</string>
+    <string name="simple_fragment_no_viewfinder_sample">Simple Fragment With No ViewFinder Activity</string>
     <string name="simple_scanner_fragment_activity">ZBar Scanner - Simple Fragment Activity</string>
     <string name="simple_activity_sample">Simple Activity Sample</string>
     <string name="simple_fragment_sample">Simple Fragment Sample</string>

--- a/zbar/build.gradle
+++ b/zbar/build.gradle
@@ -10,6 +10,7 @@ ext {
 
 dependencies {
     //compile project(":core")
-    compile 'me.dm7.barcodescanner:core:1.9'
+    //compile 'me.dm7.barcodescanner:core:1.9'
+    compile project(':core')
     compile fileTree(dir: 'libs', include: '*.jar')
 }

--- a/zxing-sample/build.gradle
+++ b/zxing-sample/build.gradle
@@ -2,7 +2,8 @@ apply plugin: 'com.android.application'
 
 dependencies {
     //compile project(":zxing")
-    compile 'me.dm7.barcodescanner:zxing:1.9'
+    //compile 'me.dm7.barcodescanner:zxing:1.9'
+    compile project(':zxing')
     compile supportLibraryDependency
     compile 'com.android.support:appcompat-v7:24.1.1'
     compile 'com.android.support:design:24.1.1'

--- a/zxing-sample/src/main/AndroidManifest.xml
+++ b/zxing-sample/src/main/AndroidManifest.xml
@@ -41,6 +41,11 @@
                 android:label="@string/simple_scanner_fragment_activity">
         </activity>
 
+      <activity android:name=".SimpleScannerNoViewFinderFragmentActivity"
+          android:theme="@style/AppOverlayTheme"
+          android:label="@string/simple_scanner_no_view_finder_fragment_activity">
+      </activity>
+
         <activity android:name=".FullScreenScannerFragmentActivity"
                   android:theme="@style/AppOverlayTheme"
                 android:label="@string/full_screen_scanner_fragment_activity">

--- a/zxing-sample/src/main/java/me/dm7/barcodescanner/zxing/sample/MainActivity.java
+++ b/zxing-sample/src/main/java/me/dm7/barcodescanner/zxing/sample/MainActivity.java
@@ -35,6 +35,10 @@ public class MainActivity extends AppCompatActivity {
         launchActivity(SimpleScannerFragmentActivity.class);
     }
 
+    public void launchSimpleNoViewFinderFragmentActivity(View v) {
+        launchActivity(SimpleScannerNoViewFinderFragmentActivity.class);
+    }
+
     public void launchFullActivity(View v) {
         launchActivity(FullScannerActivity.class);
     }

--- a/zxing-sample/src/main/java/me/dm7/barcodescanner/zxing/sample/SimpleScannerNoViewFinderFragment.java
+++ b/zxing-sample/src/main/java/me/dm7/barcodescanner/zxing/sample/SimpleScannerNoViewFinderFragment.java
@@ -1,0 +1,54 @@
+package me.dm7.barcodescanner.zxing.sample;
+
+import android.os.Bundle;
+import android.os.Handler;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Toast;
+
+import com.google.zxing.Result;
+
+import me.dm7.barcodescanner.zxing.ZXingScannerView;
+
+public class SimpleScannerNoViewFinderFragment extends Fragment implements ZXingScannerView.ResultHandler {
+    private ZXingScannerView mScannerView;
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        mScannerView = new ZXingScannerView(getActivity());
+        return mScannerView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        mScannerView.setResultHandler(this);
+        mScannerView.hideViewFinder();
+        mScannerView.startCamera();
+    }
+
+    @Override
+    public void handleResult(Result rawResult) {
+        Toast.makeText(getActivity(), "Contents = " + rawResult.getText() +
+                ", Format = " + rawResult.getBarcodeFormat().toString(), Toast.LENGTH_SHORT).show();
+        // Note:
+        // * Wait 2 seconds to resume the preview.
+        // * On older devices continuously stopping and resuming camera preview can result in freezing the app.
+        // * I don't know why this is the case but I don't have the time to figure out.
+        Handler handler = new Handler();
+        handler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                mScannerView.resumeCameraPreview(SimpleScannerNoViewFinderFragment.this);
+            }
+        }, 2000);
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        mScannerView.stopCamera();
+    }
+}

--- a/zxing-sample/src/main/java/me/dm7/barcodescanner/zxing/sample/SimpleScannerNoViewFinderFragmentActivity.java
+++ b/zxing-sample/src/main/java/me/dm7/barcodescanner/zxing/sample/SimpleScannerNoViewFinderFragmentActivity.java
@@ -1,0 +1,12 @@
+package me.dm7.barcodescanner.zxing.sample;
+
+import android.os.Bundle;
+
+public class SimpleScannerNoViewFinderFragmentActivity extends BaseScannerActivity {
+    @Override
+    public void onCreate(Bundle state) {
+        super.onCreate(state);
+        setContentView(R.layout.activity_simple_scanner_no_view_finder_fragment);
+        setupToolbar();
+    }
+}

--- a/zxing-sample/src/main/res/layout/activity_main.xml
+++ b/zxing-sample/src/main/res/layout/activity_main.xml
@@ -34,6 +34,10 @@
                     android:text="@string/simple_fragment_sample"
                     android:onClick="launchSimpleFragmentActivity" />
             <Button android:layout_height="wrap_content"
+                android:layout_width="match_parent"
+                android:text="@string/simple_no_view_finder_fragment_sample"
+                android:onClick="launchSimpleNoViewFinderFragmentActivity" />
+            <Button android:layout_height="wrap_content"
                     android:layout_width="match_parent"
                     android:text="@string/activity_sample"
                     android:onClick="launchFullActivity" />

--- a/zxing-sample/src/main/res/layout/activity_simple_scanner_no_view_finder_fragment.xml
+++ b/zxing-sample/src/main/res/layout/activity_simple_scanner_no_view_finder_fragment.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <fragment android:name="me.dm7.barcodescanner.zxing.sample.SimpleScannerNoViewFinderFragment"
+          android:id="@+id/scanner_fragment"
+          android:layout_weight="1"
+          android:layout_width="match_parent"
+          android:layout_height="match_parent" />
+
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_gravity="top"
+        android:minHeight="?attr/actionBarSize"
+        android:background="@color/actionbar_opacity"
+        app:theme="@style/TransparentToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+</FrameLayout>

--- a/zxing-sample/src/main/res/values/strings.xml
+++ b/zxing-sample/src/main/res/values/strings.xml
@@ -6,9 +6,11 @@
     <string name="custom_view_finder_scanner_activity">ZXing Scanner - Custom View Finder Activity</string>
     <string name="scaling_scanner_activity">ZXing Scanner - Scaling Activity</string>
     <string name="simple_scanner_fragment_activity">ZXing Scanner - Simple Fragment Activity</string>
+    <string name="simple_scanner_no_view_finder_fragment_activity">ZXing Scanner - Simple No ViewFinder Fragment Activity</string>
     <string name="full_screen_scanner_fragment_activity">ZXing Scanner - Full Screen Fragment Activity</string>
     <string name="simple_activity_sample">Simple Activity Sample</string>
     <string name="simple_fragment_sample">Simple Fragment Sample</string>
+    <string name="simple_no_view_finder_fragment_sample">Simple No ViewFinder Fragment Sample</string>
     <string name="activity_sample">Full Activity Sample</string>
     <string name="fragment_sample">Full Fragment Sample</string>
     <string name="full_screen_sample">Full Screen Fragment Sample</string>

--- a/zxing/build.gradle
+++ b/zxing/build.gradle
@@ -10,6 +10,7 @@ ext {
 
 dependencies {
     //compile project(":core")
-    compile 'me.dm7.barcodescanner:core:1.9'
+    //compile 'me.dm7.barcodescanner:core:1.9'
     compile 'com.google.zxing:core:3.2.1'
+    compile project(':core')
 }


### PR DESCRIPTION
Created method "hideViewFider" that, called before starting the camera, hides the viewfinder.

Calling this method (before starting the camera) you can hide the viewfinder from the preview.
Created also examples.

Tested both for zxing and zbar.

I had to change also gradle files to make the other projects use the source code instead of the gradle repositories, and run without conflicts.
