### PR TITLE
workaround for isFlashSupported throwing a RuntimeException

### DIFF
--- a/core/src/main/java/me/dm7/barcodescanner/core/CameraUtils.java
+++ b/core/src/main/java/me/dm7/barcodescanner/core/CameraUtils.java
@@ -5,59 +5,72 @@ import android.hardware.Camera;
 import java.util.List;
 
 public class CameraUtils {
-    /** A safe way to get an instance of the Camera object. */
-    public static Camera getCameraInstance() {
-        return getCameraInstance(getDefaultCameraId());
-    }
+	/**
+	 * A safe way to get an instance of the Camera object.
+	 */
+	public static Camera getCameraInstance() {
+		return getCameraInstance(getDefaultCameraId());
+	}
 
-    /** Favor back-facing camera by default. If none exists, fallback to whatever camera is available **/
-    public static int getDefaultCameraId() {
-        int numberOfCameras = Camera.getNumberOfCameras();
-        Camera.CameraInfo cameraInfo = new Camera.CameraInfo();
-        int defaultCameraId = -1;
-        for (int i = 0; i < numberOfCameras; i++) {
-            defaultCameraId = i;
-            Camera.getCameraInfo(i, cameraInfo);
-            if (cameraInfo.facing == Camera.CameraInfo.CAMERA_FACING_BACK) {
-                return i;
-            }
-        }
-        return defaultCameraId;
-    }
+	/**
+	 * Favor back-facing camera by default. If none exists, fallback to whatever camera is available
+	 **/
+	public static int getDefaultCameraId() {
+		int numberOfCameras = Camera.getNumberOfCameras();
+		Camera.CameraInfo cameraInfo = new Camera.CameraInfo();
+		int defaultCameraId = -1;
+		for (int i = 0; i < numberOfCameras; i++) {
+			defaultCameraId = i;
+			Camera.getCameraInfo(i, cameraInfo);
+			if (cameraInfo.facing == Camera.CameraInfo.CAMERA_FACING_BACK) {
+				return i;
+			}
+		}
+		return defaultCameraId;
+	}
 
-    /** A safe way to get an instance of the Camera object. */
-    public static Camera getCameraInstance(int cameraId) {
-        Camera c = null;
-        try {
-            if(cameraId == -1) {
-                c = Camera.open(); // attempt to get a Camera instance
-            } else {
-                c = Camera.open(cameraId); // attempt to get a Camera instance
-            }
-        }
-        catch (Exception e) {
-            // Camera is not available (in use or does not exist)
-        }
-        return c; // returns null if camera is unavailable
-    }
+	/**
+	 * A safe way to get an instance of the Camera object.
+	 */
+	public static Camera getCameraInstance(int cameraId) {
+		Camera c = null;
+		try {
+			if (cameraId == -1) {
+				c = Camera.open(); // attempt to get a Camera instance
+			} else {
+				c = Camera.open(cameraId); // attempt to get a Camera instance
+			}
+		} catch (Exception e) {
+			// Camera is not available (in use or does not exist)
+		}
+		return c; // returns null if camera is unavailable
+	}
 
-    public static boolean isFlashSupported(Camera camera) {
-        /* Credits: Top answer at http://stackoverflow.com/a/19599365/868173 */
-        if (camera != null) {
-            Camera.Parameters parameters = camera.getParameters();
+	public static boolean isFlashSupported(Camera camera) {
+		/* Credits: Top answer at http://stackoverflow.com/a/19599365/868173 */
 
-            if (parameters.getFlashMode() == null) {
-                return false;
-            }
+		boolean retVal = true;
 
-            List<String> supportedFlashModes = parameters.getSupportedFlashModes();
-            if (supportedFlashModes == null || supportedFlashModes.isEmpty() || supportedFlashModes.size() == 1 && supportedFlashModes.get(0).equals(Camera.Parameters.FLASH_MODE_OFF)) {
-                return false;
-            }
-        } else {
-            return false;
-        }
+		if (camera != null) {
+			try {
+				Camera.Parameters parameters = camera.getParameters();
 
-        return true;
-    }
+				if (parameters.getFlashMode() == null) {
+					retVal = false;
+				}
+
+				List<String> supportedFlashModes = parameters.getSupportedFlashModes();
+				if (supportedFlashModes == null || supportedFlashModes.isEmpty() || supportedFlashModes.size() == 1 && supportedFlashModes.get(0).equals(Camera.Parameters.FLASH_MODE_OFF)) {
+					retVal = false;
+				}
+			} catch (RuntimeException e) {
+				// may be: "Fatal Exception: java.lang.RuntimeException: getParameters failed (empty parameters)"
+				retVal = false;
+			}
+		} else {
+			retVal = false;
+		}
+
+		return retVal;
+	}
 }


### PR DESCRIPTION
isFlashSupported may throw a RuntimeException.

> Fatal Exception: java.lang.RuntimeException: getParameters failed (empty parameters)
> at android.hardware.Camera.native_getParameters(Camera.java)
> at android.hardware.Camera.getParameters(Camera.java:1996)
> at me.dm7.barcodescanner.core.CameraUtils.isFlashSupported(SourceFile:32)
> at me.dm7.barcodescanner.core.BarcodeScannerView.setFlash(SourceFile:130)
> at me.dm7.barcodescanner.core.BarcodeScannerView.setupCameraPreview(SourceFile:73)
> at me.dm7.barcodescanner.core.CameraHandlerThread$1$1.run(SourceFile:31)
> at android.os.Handler.handleCallback(Handler.java:739)
> at android.os.Handler.dispatchMessage(Handler.java:95)
> at android.os.Looper.loop(Looper.java:158)
> at android.app.ActivityThread.main(ActivityThread.java:7225)
> at java.lang.reflect.Method.invoke(Method.java)
> at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1230)

This is a workaround which catches the exception and assumes that flash is not supported.