### PR TITLE
Fixed Nexus 5x zxing barcode scanning issue(Nexus upside down issue)

### DIFF
--- a/core/src/main/java/me/dm7/barcodescanner/core/BarcodeScannerView.java
+++ b/core/src/main/java/me/dm7/barcodescanner/core/BarcodeScannerView.java
@@ -21,6 +21,10 @@ public abstract class BarcodeScannerView extends FrameLayout implements Camera.P
     private boolean mAutofocusState = true;
     private boolean mShouldScaleToFill = true;
 
+    public CameraPreview getCameraPreview() {
+        return mPreview;
+    }
+
     public BarcodeScannerView(Context context) {
         super(context);
     }

--- a/zxing/build.gradle
+++ b/zxing/build.gradle
@@ -9,7 +9,7 @@ ext {
 }
 
 dependencies {
-    //compile project(":core")
+    compile project(":core")
     compile libraries.barcodescanner_core
     compile libraries.zxing_core
 }

--- a/zxing/src/main/java/me/dm7/barcodescanner/zxing/ZXingScannerView.java
+++ b/zxing/src/main/java/me/dm7/barcodescanner/zxing/ZXingScannerView.java
@@ -122,7 +122,7 @@ public class ZXingScannerView extends BarcodeScannerView {
              * Fixed Nexus 5x barcode scanning issues
              * https://github.com/dm77/barcodescanner/issues/280
              * https://github.com/dm77/barcodescanner/issues/313
-             * The above code actually rotates only 90 degree.It works fine
+             * The above commented code actually rotates only 90 degree.It works fine
              * if device having normal camera orientation(Landscape).But
              * for Nexus 5X device camera orientation is reverse landscape and
              * it rotates 90 degree,so the preview data will be upside down.


### PR DESCRIPTION
Hi I have fixed Nexus 5x barcode scanning issues
#280
#313
The existing data rotation code actually rotates only 90 degree.It works fine
if device having normal camera orientation(Landscape).But
for Nexus 5X device camera orientation is reverse landscape and
it rotates 90 degree,so the preview data will be upside down.
Normally when we use rectangle at center,it is very hard to identify this issue,
because zxing scans barcode even if it is in reverse angle.When we move the
rectangle points we can identify this issue.
To fix this issue,I have rotated data based on camera orientation.Now it rotates
270 degree on Nexus device and 90 degree on normal orientation devices.