### PR TITLE
Allow for disabling scanning

### DIFF
--- a/core/src/main/java/me/dm7/barcodescanner/core/BarcodeScannerView.java
+++ b/core/src/main/java/me/dm7/barcodescanner/core/BarcodeScannerView.java
@@ -22,6 +22,7 @@ public abstract class BarcodeScannerView extends FrameLayout implements Camera.P
     private Boolean mFlashState;
     private boolean mAutofocusState = true;
     private boolean mShouldScaleToFill = true;
+    private boolean mScanEnabled = true;
 
     private boolean mIsLaserEnabled = true;
     @ColorInt private int mLaserColor = getResources().getColor(R.color.viewfinder_laser);
@@ -35,6 +36,7 @@ public abstract class BarcodeScannerView extends FrameLayout implements Camera.P
     private float mBorderAlpha = 1.0f;
     private int mViewFinderOffset = 0;
     private float mAspectTolerance = 0.1f;
+
 
     public BarcodeScannerView(Context context) {
         super(context);
@@ -300,6 +302,10 @@ public abstract class BarcodeScannerView extends FrameLayout implements Camera.P
     public void setShouldScaleToFill(boolean shouldScaleToFill) {
         mShouldScaleToFill = shouldScaleToFill;
     }
+
+    public void setScanEnabled(boolean isEnabled) { mScanEnabled = isEnabled; }
+
+    public boolean getScanEnabled() { return mScanEnabled; }
 
     public void setAspectTolerance(float aspectTolerance) {
         mAspectTolerance = aspectTolerance;

--- a/core/src/main/res/values/attrs.xml
+++ b/core/src/main/res/values/attrs.xml
@@ -13,5 +13,6 @@
         <attr name="squaredFinder" format="boolean" />
         <attr name="borderAlpha" format="float" />
         <attr name="finderOffset" format="dimension" />
+        <attr name="scanEnabled" format="boolean" />
     </declare-styleable>
 </resources>

--- a/zbar/src/main/java/me/dm7/barcodescanner/zbar/ZBarScannerView.java
+++ b/zbar/src/main/java/me/dm7/barcodescanner/zbar/ZBarScannerView.java
@@ -77,7 +77,7 @@ public class ZBarScannerView extends BarcodeScannerView {
 
     @Override
     public void onPreviewFrame(byte[] data, Camera camera) {
-        if(mResultHandler == null) {
+        if(mResultHandler == null || !getScanEnabled()) {
             return;
         }
 
@@ -134,7 +134,7 @@ public class ZBarScannerView extends BarcodeScannerView {
                         // onPreviewFrame.
                         ResultHandler tmpResultHandler = mResultHandler;
                         mResultHandler = null;
-                        
+
                         stopCameraPreview();
                         if (tmpResultHandler != null) {
                             tmpResultHandler.handleResult(rawResult);

--- a/zxing/src/main/java/me/dm7/barcodescanner/zxing/ZXingScannerView.java
+++ b/zxing/src/main/java/me/dm7/barcodescanner/zxing/ZXingScannerView.java
@@ -96,10 +96,10 @@ public class ZXingScannerView extends BarcodeScannerView {
 
     @Override
     public void onPreviewFrame(byte[] data, Camera camera) {
-        if(mResultHandler == null) {
+        if(mResultHandler == null && !getScanEnabled()) {
             return;
         }
-        
+
         try {
             Camera.Parameters parameters = camera.getParameters();
             Camera.Size size = parameters.getPreviewSize();


### PR DESCRIPTION
This aims to resolve issue #467. 

There are occasions where disabling the scanner would be very nice. For example, if I would like to show a dialog over the screen it would be helpful to allow the scanner to continue to show the camera view, but prevent random scans from happening in the background. These changes allow for calling `.setScanEnabled(false)` to allow for the scanner to be disabled. This allows for the background to continue to look the same without the awkward screen freezes and vibrates that can occur due to barcodes being detected.