### PR TITLE
Feature/zoom

### DIFF
--- a/core/src/main/java/me/dm7/barcodescanner/core/BarcodeScannerView.java
+++ b/core/src/main/java/me/dm7/barcodescanner/core/BarcodeScannerView.java
@@ -20,6 +20,7 @@ public abstract class BarcodeScannerView extends FrameLayout implements Camera.P
     private Rect mFramingRectInPreview;
     private CameraHandlerThread mCameraHandlerThread;
     private Boolean mFlashState;
+    private int mZoom;
     private boolean mAutofocusState = true;
     private boolean mShouldScaleToFill = true;
 
@@ -288,6 +289,41 @@ public abstract class BarcodeScannerView extends FrameLayout implements Camera.P
             }
             mCameraWrapper.mCamera.setParameters(parameters);
         }
+    }
+
+    /**
+     * Set the zoom level
+     * @param zoom the new zoom level
+     * @return true if it worked
+     */
+    public boolean setZoom(int zoom) {
+        if(mCameraWrapper != null && CameraUtils.isZoomSupported(mCameraWrapper.mCamera)) {
+
+            Camera.Parameters parameters = mCameraWrapper.mCamera.getParameters();
+            if (zoom>=0 && zoom <= parameters.getMaxZoom()) {
+                mZoom = zoom;
+                parameters.setZoom(zoom);
+                mCameraWrapper.mCamera.setParameters(parameters);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public int getZoom() {
+        if(mCameraWrapper != null && CameraUtils.isZoomSupported(mCameraWrapper.mCamera)) {
+            Camera.Parameters parameters = mCameraWrapper.mCamera.getParameters();
+            return parameters.getZoom();
+        }
+        return -1;
+    }
+
+    public int getMaxZoom() {
+        if(mCameraWrapper != null && CameraUtils.isZoomSupported(mCameraWrapper.mCamera)) {
+            Camera.Parameters parameters = mCameraWrapper.mCamera.getParameters();
+            return parameters.getMaxZoom();
+        }
+        return 0;
     }
 
     public void setAutoFocus(boolean state) {

--- a/core/src/main/java/me/dm7/barcodescanner/core/CameraUtils.java
+++ b/core/src/main/java/me/dm7/barcodescanner/core/CameraUtils.java
@@ -60,4 +60,9 @@ public class CameraUtils {
 
         return true;
     }
+    public static boolean isZoomSupported(Camera camera) {
+        return camera != null
+                && camera.getParameters() != null
+                && camera.getParameters().isZoomSupported();
+    }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -13,7 +13,10 @@ ext.libraries = [
         appcompat_v7        : "com.android.support:appcompat-v7:$versions.support_lib",
         design_support      : "com.android.support:design:$versions.support_lib",
         zxing_core          : "com.google.zxing:core:$versions.zxing",
-        barcodescanner_core : "me.dm7.barcodescanner:core:$versions.barcodescanner",
-        barcodescanner_zbar : "me.dm7.barcodescanner:zbar:$versions.barcodescanner",
-        barcodescanner_zxing: "me.dm7.barcodescanner:zxing:$versions.barcodescanner"
+        //barcodescanner_core : "me.dm7.barcodescanner:core:$versions.barcodescanner",
+        //barcodescanner_zbar : "me.dm7.barcodescanner:zbar:$versions.barcodescanner",
+        //barcodescanner_zxing: "me.dm7.barcodescanner:zxing:$versions.barcodescanner"
+        barcodescanner_core : project(":core"),
+        barcodescanner_zbar : project(":zbar"),
+        barcodescanner_zxing: project(":zxing")
 ]

--- a/zxing-sample/src/main/java/me/dm7/barcodescanner/zxing/sample/ScalingScannerActivity.java
+++ b/zxing-sample/src/main/java/me/dm7/barcodescanner/zxing/sample/ScalingScannerActivity.java
@@ -12,9 +12,11 @@ import me.dm7.barcodescanner.zxing.ZXingScannerView;
 
 public class ScalingScannerActivity extends BaseScannerActivity implements ZXingScannerView.ResultHandler {
     private static final String FLASH_STATE = "FLASH_STATE";
+    private static final String FLASH_ZOOM = "FLASH_ZOOM";
 
     private ZXingScannerView mScannerView;
     private boolean mFlash;
+    private boolean mZoom;
 
     @Override
     public void onCreate(Bundle state) {
@@ -35,6 +37,7 @@ public class ScalingScannerActivity extends BaseScannerActivity implements ZXing
         mScannerView.setAspectTolerance(0.2f);
         mScannerView.startCamera();
         mScannerView.setFlash(mFlash);
+        mScannerView.setZoom(mZoom?mScannerView.getMaxZoom():0);
     }
 
     @Override
@@ -47,6 +50,7 @@ public class ScalingScannerActivity extends BaseScannerActivity implements ZXing
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putBoolean(FLASH_STATE, mFlash);
+        outState.putBoolean(FLASH_ZOOM, mZoom);
     }
 
     @Override
@@ -70,5 +74,10 @@ public class ScalingScannerActivity extends BaseScannerActivity implements ZXing
     public void toggleFlash(View v) {
         mFlash = !mFlash;
         mScannerView.setFlash(mFlash);
+    }
+
+    public void toggleZoom(View view) {
+        mZoom = !mZoom;
+        mScannerView.setZoom(mZoom?mScannerView.getMaxZoom():0);
     }
 }

--- a/zxing-sample/src/main/res/layout-land/activity_scaling_scanner.xml
+++ b/zxing-sample/src/main/res/layout-land/activity_scaling_scanner.xml
@@ -37,6 +37,11 @@
                 android:onClick="toggleFlash"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"/>
+            <Button
+                android:text="@string/toggle_zoom"
+                android:onClick="toggleZoom"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
         </LinearLayout>
     </LinearLayout>
 </LinearLayout>

--- a/zxing-sample/src/main/res/layout/activity_scaling_scanner.xml
+++ b/zxing-sample/src/main/res/layout/activity_scaling_scanner.xml
@@ -38,6 +38,12 @@
                 android:onClick="toggleFlash"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"/>
+            <Button
+                android:text="@string/toggle_zoom"
+                android:layout_weight="1"
+                android:onClick="toggleZoom"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
         </LinearLayout>
     </LinearLayout>
 </LinearLayout>

--- a/zxing-sample/src/main/res/values/strings.xml
+++ b/zxing-sample/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="custom_view_finder_sample">Custom View Finder Sample</string>
     <string name="scaling_sample">Scaling Sample</string>
     <string name="toggle_flash">Flash</string>
+    <string name="toggle_zoom">Zoom</string>
     <string name="flash_on">Flash [ON]</string>
     <string name="flash_off">Flash [OFF]</string>
     <string name="auto_focus_on">Auto Focus [ON]</string>


### PR DESCRIPTION
Add ability to zoom the preview so that terrible cameras have a much better chance of reading barcodes and QR codes.

I've tested this with a UMIDIGI A3, which has such a terrible camera that a small barcode cannot be read. Using the "zoom to max" feature implemented in ScalingScannerActivity.java, the otherwise unreadable barcode is easily read.